### PR TITLE
Add WaniKani Vocab cache, fix unnecessary user request on every page, rework numeric filtering

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -253,21 +253,6 @@ async function tryWaniKani(apiKey) {
         console.error("No API key provided! Please use the options page to specify your API key.");
         return [];
     }
-    
-    var userPromise = new Promise((resolve, reject) => {
-        chrome.runtime.sendMessage({ type: "fetchUserObject" }, (userObject) => {
-            const error = chrome.runtime.lastError;
-            if (error) {
-                console.error(error.message);
-                reject(error);
-            } else {
-                resolve(userObject);
-            }
-        });
-    });
-
-    var username = await userPromise.then(result => result.username);
-    console.log("WaniKani Username: " + username);
 
     return new Promise((resolve, reject) => {
         chrome.runtime.sendMessage({ type: "fetchVocab" }, (vocabList) => {

--- a/js/content.js
+++ b/js/content.js
@@ -42,7 +42,8 @@ function main(cache_local) {
             vocabDictionary,
             cache_local.wanikanify_vocab,
             cache_local.wanikanify_googleVocabKey,
-            cache_sync.wanikanify_customvocab);
+            cache_sync.wanikanify_customvocab
+        );
 
         $("body *:not(noscript):not(script):not(style)").replaceText(/\b(\S+?)\b/g, dictionaryCallback);
     });
@@ -113,6 +114,12 @@ function importCustomVocab(vocabDictionary, cache_local, cache_sync) {
     }
 }
 
+// this will not catch numbers with delimeters other than "." (like for example "1,000")
+    function isNumeric(str) { 
+        return !isNaN(str) &&
+            !isNaN(parseFloat(str))
+    }
+
 // ------------------------------------------------------------------------------------------------
 // Remove numbers from dictionary
 function numberRemoval(vocabDictionary, cache_local, cache_sync) {
@@ -121,40 +128,9 @@ function numberRemoval(vocabDictionary, cache_local, cache_sync) {
         return vocabDictionary;
     }
 
-    var Nadd = 0;
-    var Yadd = 0;
-    var newVocabDictionary = {};
-    vocabDictionary = Object.entries(vocabDictionary);
-    //console.log(Object.entries(vocabDictionary));
-
-    for (var i = 0; i < vocabDictionary.length; ++i) {
-        var temp = null;
-        var key = Object.keys(vocabDictionary)[i];
-        var valueEng = Object.values(vocabDictionary)[i][0];
-        var valueJap = Object.values(vocabDictionary)[i][1];
-        //console.log( valueEng + " " + valueJap );
-
-        try {
-            if(!hasWhiteSpace(valueEng)) {
-                temp = parseInt(valueEng);
-                
-                if(Number.isFinite(temp)) {
-                    //console.log("N-Add: " + valueEng);
-                    Nadd++;
-                } else {
-                    //console.log("Y-Add: " + valueEng);
-                    Yadd++;
-                    newVocabDictionary[valueEng] = valueJap;
-                }
-            }
-        } catch(error) { 
-            console.log(error);
-        }
-    }
-
-    //console.log(Object.entries(newVocabDictionary));
-    console.log("  - Numbers removed " + Nadd + " and items left untouched " + Yadd);
-    return newVocabDictionary;
+    return  Object.fromEntries(
+        Object.entries(vocabDictionary).filter(x => !isNumeric(x[0]))
+        );
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/js/options.js
+++ b/js/options.js
@@ -645,6 +645,22 @@ function restore_options() {
     );
 }
 
+async function test_api_key() {
+    var userPromise = new Promise((resolve, reject) => {
+        chrome.runtime.sendMessage({ type: "fetchUserObject" }, (userObject) => {
+            const error = chrome.runtime.lastError;
+            if (error) {
+                console.error(error.message);
+                reject(error);
+            } else {
+                resolve(userObject);
+            }
+        });
+    });
+
+    var username = await userPromise.then(result => result?.username);
+    alert(username ? `Successfully connected with username ${username}` : `Failed to connect to waniKani, the APIKey is most likely invalid (remember to press Save at the bottom of the page after changing the key)`);
+}
 // ------------------------------------------------------------------------------------------------
 function clear_cache() {
     console.log("clear_cache()");
@@ -669,4 +685,5 @@ document.addEventListener('DOMContentLoaded', function() {
     $('#clearCache').click(clear_cache);
     $('#addBlackListItem').click(add_black_list_item);
     $('#addGoogleSpreadSheetListItem').click(add_empty_google_spread_sheet_list_item);
+    $('#testApiKey').click(test_api_key);
 });

--- a/options.html
+++ b/options.html
@@ -74,6 +74,9 @@
                 <div class="control-group" id="apiKeyControl">
                   <input class="input-xlarge" type="text" id="apiKey" placeholder="Public API Key">
                 </div>
+                <button  class="btn btn-warning" id="testApiKey">Test API Key</button>
+              </td>
+              <td>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
- Add a Cache for WaniKani Vocab that stays valid for 1 hour and works across different pages.
- Remove the unnecessary user request (which checks the validity of the api key) being done on every website. Replaced it with a button to trigger that same request in the options.
- Rework the number filtering to no longer remove all words with white spaces and be stricter in what is considered a number (only "." is now a valid delimeter). This also significantly speeds up the number removal